### PR TITLE
objects: Add file upload SDK

### DIFF
--- a/python/kadalu_content_apis/__init__.py
+++ b/python/kadalu_content_apis/__init__.py
@@ -66,9 +66,9 @@ class Connection(ConnectionBase):
         return Document.create(self, "/", path, data, object_type, immutable, version, lock)
 
     # TODO: Add path to `upload_object`
-    def upload_object(self, file_path, object_type, immutable=False, version=False, lock=False, template=None):
+    def upload_object(self, file_path, object_type, path="", immutable=False, version=False, lock=False, template=None):
         """ Create default("/") object """
-        return Document.upload(self, "/", file_path, object_type, immutable, version, lock, template)
+        return Document.upload(self, "/", file_path, object_type, path, immutable, version, lock, template)
 
 
     def list_objects(self):

--- a/python/kadalu_content_apis/__init__.py
+++ b/python/kadalu_content_apis/__init__.py
@@ -2,6 +2,7 @@
 from kadalu_content_apis.regions import Region
 from kadalu_content_apis.buckets import Bucket
 from kadalu_content_apis.objects import Document
+from kadalu_content_apis.templates import Template
 from kadalu_content_apis.helpers import ConnectionBase, APIError, json_from_response
 
 class Connection(ConnectionBase):
@@ -73,3 +74,14 @@ class Connection(ConnectionBase):
         """ Return Object/Document instance """
         return Document(self, "/", path)
 
+    def create_template(self, name, content, template_type, output_type="text", public=False):
+        """ Create Template """
+        return Template.create(self, name, content, template_type, output_type, public)
+
+    def list_templates(self):
+        """ List all templated """
+        return Template.list_templates(self)
+
+    def template(self, name):
+        """ Return Template instance """
+        return Template(self, name)

--- a/python/kadalu_content_apis/__init__.py
+++ b/python/kadalu_content_apis/__init__.py
@@ -5,7 +5,7 @@ from kadalu_content_apis.objects import Document
 from kadalu_content_apis.helpers import ConnectionBase, APIError, json_from_response
 
 class Connection(ConnectionBase):
-    def __init__(self, url, username=None, password=None, user_id=None, token=None):
+    def __init__(self, url, username=None, email=None, password=None, user_id=None, token=None):
         """Intialise Connection and Login to Kadalu Content API"""
         self.url = url.strip("/")
         super().__init__()
@@ -14,6 +14,19 @@ class Connection(ConnectionBase):
             resp = self.http_post(self.url + "/api/api-keys", {"username": username, "password": password})
 
             # TODO: Send correct error response from API when username/password/etc are wrong
+            # Currently response data seems to be empty.
+            # if resp.status != 201:
+            #     raise APIError(resp)
+
+            resp_json = json_from_response(resp)
+
+            self.user_id = resp_json["user_id"]
+            self.token = resp_json["token"]
+
+        if email is not None and password is not None:
+            resp = self.http_post(self.url + "/api/api-keys", {"email": email, "password": password})
+
+            # TODO: Send correct error response from API when email/password/etc are wrong
             # Currently response data seems to be empty.
             # if resp.status != 201:
             #     raise APIError(resp)

--- a/python/kadalu_content_apis/__init__.py
+++ b/python/kadalu_content_apis/__init__.py
@@ -65,6 +65,11 @@ class Connection(ConnectionBase):
         """ Create default("/") object """
         return Document.create(self, "/", path, data, object_type, immutable, version, lock)
 
+    # TODO: Add path to `upload_object`
+    def upload_object(self, file_path, object_type, immutable=False, version=False, lock=False, template=None):
+        """ Create default("/") object """
+        return Document.upload(self, "/", file_path, object_type, immutable, version, lock, template)
+
 
     def list_objects(self):
         """ List all default("/") objects """

--- a/python/kadalu_content_apis/buckets.py
+++ b/python/kadalu_content_apis/buckets.py
@@ -76,9 +76,9 @@ class Bucket:
         return Document.create(self.conn, self.name, path, data, object_type, immutable, version, lock)
 
 
-    def upload_object(self, file_path, object_type, immutable=False, version=False, lock=False, template=None):
+    def upload_object(self, file_path, object_type, path="", immutable=False, version=False, lock=False, template=None):
         """ Create default("/") object """
-        return Document.upload(self.conn, self.name, file_path, object_type, immutable, version, lock, template)
+        return Document.upload(self.conn, self.name, file_path, object_type, path, immutable, version, lock, template)
 
 
     def list_objects(self):

--- a/python/kadalu_content_apis/buckets.py
+++ b/python/kadalu_content_apis/buckets.py
@@ -76,6 +76,11 @@ class Bucket:
         return Document.create(self.conn, self.name, path, data, object_type, immutable, version, lock)
 
 
+    def upload_object(self, file_path, object_type, immutable=False, version=False, lock=False, template=None):
+        """ Create default("/") object """
+        return Document.upload(self.conn, self.name, file_path, object_type, immutable, version, lock, template)
+
+
     def list_objects(self):
         """ List objects with bucket-name """
         return Document.list(self.conn, self.name)

--- a/python/kadalu_content_apis/helpers.py
+++ b/python/kadalu_content_apis/helpers.py
@@ -2,6 +2,12 @@
 import json
 import urllib3
 
+import json
+import urllib3
+from urllib3.fields import RequestField
+from urllib3.filepost import encode_multipart_formdata
+
+
 class APIError(Exception):
     """ APIError Exception """
     def __init__(self, resp):
@@ -43,6 +49,54 @@ class ConnectionBase:
 
         return resp
 
+<<<<<<< Updated upstream
+=======
+
+    def http_post_upload(self, url, meta, file_name, file_content):
+        """ Send HTTP Post Request by uploading a file """
+
+        http = urllib3.PoolManager()
+
+        fields = {
+            "file": (file_name, file_content),
+        }
+
+        if meta is not None:
+            fields["meta"] = json.dumps(meta)
+
+        encoded_data, multipart_headers = encode_multipart_formdata(fields)
+
+        # TODO: Explore `request` library to simplify sending multipart_formdata
+        # multipart_headers is of the form,
+        # 'multipart/form-data; boundary=a7b8ab6d919b6933490251e1d52f5551'
+        # but we require headers['Content-Type'] to be 'Content-Type': 'multipart/form-data; boundary="a7b8ab6d919b6933490251e1d52f5551"'
+        # hence extract int(boundary) from above string assign to updated headers to take final form as,
+        # {'Content-Type': 'multipart/form-data; boundary="a7b8ab6d919b6933490251e1d52f5551"', 'Authorization': 'Bearer NNN', 'USER_ID': N}
+
+        headers = self.get_headers(file_upload=False)
+
+        # parts = multipart_headers.split(';')
+        # for part in parts:
+        #     if 'boundary' in part:
+        #         boundary = part.split('=')[1].strip()
+        #         break
+
+        boundary = multipart_headers.split("=")[1]
+        multipart_header = f'multipart/form-data; boundary="{boundary}"'
+        headers['Content-Type'] = multipart_header
+
+        # Send the request and get the response
+        resp = http.request(
+            method="POST",
+            url=url,
+            body=encoded_data,
+            headers=headers
+        )
+
+        return resp
+
+
+>>>>>>> Stashed changes
     def http_put(self, url, data):
         """ Send HTTP Put Request with headers """
 

--- a/python/kadalu_content_apis/helpers.py
+++ b/python/kadalu_content_apis/helpers.py
@@ -17,8 +17,6 @@ class ConnectionBase:
         self.token = ""
         self.user_id = ""
 
-        print(self.token, self.user_id, "BaseClass")
-
     def get_headers(self):
         """ Returns token and user-id as headers """
 
@@ -122,7 +120,6 @@ def to_object(name, data):
 
 def json_from_response(resp):
     """ Wrapper to convert HTTP response into JSON """
-    print(resp.data)
     return json.loads(resp.data.decode('utf-8'))
 
 

--- a/python/kadalu_content_apis/helpers.py
+++ b/python/kadalu_content_apis/helpers.py
@@ -1,12 +1,7 @@
 # noqa # pylint: disable=missing-module-docstring
 import json
 import urllib3
-
-import json
-import urllib3
-from urllib3.fields import RequestField
 from urllib3.filepost import encode_multipart_formdata
-
 
 class APIError(Exception):
     """ APIError Exception """
@@ -50,7 +45,7 @@ class ConnectionBase:
         return resp
 
 
-    def http_post_upload(self, url, meta, file_name, file_content):
+    def http_post_upload(self, url, meta, file_name="", file_content=""):
         """ Send HTTP Post Request by uploading a file """
 
         http = urllib3.PoolManager()
@@ -71,13 +66,7 @@ class ConnectionBase:
         # hence extract int(boundary) from above string assign to updated headers to take final form as,
         # {'Content-Type': 'multipart/form-data; boundary="a7b8ab6d919b6933490251e1d52f5551"', 'Authorization': 'Bearer NNN', 'USER_ID': N}
 
-        headers = self.get_headers(file_upload=False)
-
-        # parts = multipart_headers.split(';')
-        # for part in parts:
-        #     if 'boundary' in part:
-        #         boundary = part.split('=')[1].strip()
-        #         break
+        headers = self.get_headers()
 
         boundary = multipart_headers.split("=")[1]
         multipart_header = f'multipart/form-data; boundary="{boundary}"'
@@ -108,6 +97,7 @@ class ConnectionBase:
 
         return resp
 
+
     def http_delete(self, url):
         """ Send HTTP Delete Request """
 
@@ -119,6 +109,7 @@ class ConnectionBase:
         )
 
         return resp
+
 
     def http_get(self, url):
         """ Send HTTP Get request with headers """
@@ -150,6 +141,7 @@ class Generic:
             else:
                 self.class_highlights.append(val)
                 setattr(self, key, val)
+
 
     def __str__(self):
         # Some response may have 'int' values, convert them into 'str'

--- a/python/kadalu_content_apis/helpers.py
+++ b/python/kadalu_content_apis/helpers.py
@@ -25,7 +25,7 @@ class ConnectionBase:
             headers["Authorization"] = f"Bearer {self.token}"
 
         if self.user_id != "":
-            headers["User_ID"] = self.user_id
+            headers["USER_ID"] = self.user_id
 
         return headers
 

--- a/python/kadalu_content_apis/objects.py
+++ b/python/kadalu_content_apis/objects.py
@@ -8,7 +8,7 @@ class Document:
         self.path = path
 
     @classmethod
-    def create(cls, conn, bucket_name, path, data, obj_type, immutable, version, lock):
+    def create(cls, conn, bucket_name, path, data, object_type, immutable, version, lock):
         """ Create object of both default("/") and with bucket-name """
 
         if bucket_name == "/":
@@ -19,7 +19,7 @@ class Document:
             url,
             {
                 "path": path,
-                "type": obj_type,
+                "type": object_type,
                 "data": data,
                 "immutable": immutable,
                 "version": version,
@@ -53,7 +53,6 @@ class Document:
             url = f"{self.conn.url}/api/buckets/{self.bucket_name}/objects/{self.path}"
 
         resp = self.conn.http_get(url)
-        print(resp.status)
         return response_object_or_error("Object", resp, 200)
 
 

--- a/python/kadalu_content_apis/objects.py
+++ b/python/kadalu_content_apis/objects.py
@@ -1,3 +1,4 @@
+import os
 from kadalu_content_apis.helpers import response_object_or_error
 
 class Document:
@@ -16,7 +17,7 @@ class Document:
             url = f"{conn.url}/api/objects"
         else:
             url = f"{conn.url}/api/buckets/{bucket_name}/objects"
-        resp = conn.http_post(
+        resp = conn.http_post_upload(
             url,
             {
                 "path": path,
@@ -31,10 +32,9 @@ class Document:
 
 
     @classmethod
-    def upload(cls, conn, bucket_name, file_path, object_type, immutable, version, lock, template):
+    def upload(cls, conn, bucket_name, file_path, object_type, path, immutable, version, lock, template):
         """ Upload object data at file_path """
 
-        file_name = file_path
         file_content = ""
 
         if bucket_name == "/":
@@ -45,8 +45,12 @@ class Document:
         with open(file_path, "r") as file:
             file_content = file.read()
 
+        # If path is empty, set filepath as path excluding the relative path
+        if path == "":
+            path = os.path.basename(file_path)
+
         meta = {
-                "path": file_path,
+                "path": path,
                 "type": object_type,
                 "immutable": immutable,
                 "version": version,
@@ -56,7 +60,7 @@ class Document:
 
         resp = conn.http_post_upload(
             url,
-            meta, file_name, file_content
+            meta, file_path, file_content
         )
         return response_object_or_error("Object", resp, 201)
 

--- a/python/kadalu_content_apis/objects.py
+++ b/python/kadalu_content_apis/objects.py
@@ -7,6 +7,7 @@ class Document:
         self.bucket_name = bucket_name
         self.path = path
 
+
     @classmethod
     def create(cls, conn, bucket_name, path, data, object_type, immutable, version, lock):
         """ Create object of both default("/") and with bucket-name """
@@ -25,6 +26,37 @@ class Document:
                 "version": version,
                 "lock": lock
             }
+        )
+        return response_object_or_error("Object", resp, 201)
+
+
+    @classmethod
+    def upload(cls, conn, bucket_name, file_path, object_type, immutable, version, lock, template):
+        """ Upload object data at file_path """
+
+        file_name = file_path
+        file_content = ""
+
+        if bucket_name == "/":
+            url = f"{conn.url}/api/objects"
+        else:
+            url = f"{conn.url}/api/buckets/{bucket_name}/objects"
+
+        with open(file_path, "r") as file:
+            file_content = file.read()
+
+        meta = {
+                "path": file_path,
+                "type": object_type,
+                "immutable": immutable,
+                "version": version,
+                "lock": lock,
+                "template": template
+        }
+
+        resp = conn.http_post_upload(
+            url,
+            meta, file_name, file_content
         )
         return response_object_or_error("Object", resp, 201)
 

--- a/python/kadalu_content_apis/regions.py
+++ b/python/kadalu_content_apis/regions.py
@@ -6,6 +6,7 @@ class Region:
         self.conn = conn
         self.name = name
 
+
     @classmethod
     def create(cls, conn, name, address):
         """ Create region """

--- a/python/kadalu_content_apis/templates.py
+++ b/python/kadalu_content_apis/templates.py
@@ -6,6 +6,7 @@ class Template:
         self.conn = conn
         self.name = name
 
+
     # TODO: Handle Invalid Region Name, when only name is passed.
     @classmethod
     def create(cls, conn, name, content, template_type, output_type, public):

--- a/python/kadalu_content_apis/templates.py
+++ b/python/kadalu_content_apis/templates.py
@@ -12,7 +12,7 @@ class Template:
     def create(cls, conn, name, content, template_type, output_type, public):
         """ Create template """
 
-        resp = conn.http_post(
+        resp = conn.http_post_upload(
             f"{conn.url}/api/templates",
             {
                 "name" : name,

--- a/python/kadalu_content_apis/templates.py
+++ b/python/kadalu_content_apis/templates.py
@@ -1,0 +1,71 @@
+from kadalu_content_apis.helpers import response_object_or_error
+
+class Template:
+    def __init__(self, conn, name):
+        """ Intialise Template """
+        self.conn = conn
+        self.name = name
+
+    # TODO: Handle Invalid Region Name, when only name is passed.
+    @classmethod
+    def create(cls, conn, name, content, template_type, output_type, public):
+        """ Create template """
+
+        resp = conn.http_post(
+            f"{conn.url}/api/templates",
+            {
+                "name" : name,
+                "content": content,
+                "type": template_type,
+                "output_type": output_type,
+                "public": public
+
+            }
+        )
+        return response_object_or_error("Template", resp, 201)
+
+
+    @classmethod
+    def list_templates(cls, conn):
+        """ List all templates """
+
+        resp = conn.http_get(
+            f"{conn.url}/api/templates"
+        )
+        return response_object_or_error("Template", resp, 200)
+
+
+    def get(self):
+        """ Return a Template """
+
+        resp = self.conn.http_get(
+            f"{self.conn.url}/api/templates/{self.name}"
+        )
+        return response_object_or_error("Template", resp, 200)
+
+
+    def update(self, name=None, content=None, template_type=None, output_type=None, public=None):
+        """ Update Template """
+
+        resp = self.conn.http_put(
+            f"{self.conn.url}/api/templates/{self.name}",
+            {
+                "name" : name,
+                "content": content,
+                "type": template_type,
+                "output_type": output_type,
+                "public": public
+            }
+        )
+
+        # Update object name so deletion can be done from the same object after updation.
+        if resp.status == 200 and name is not None:
+            self.name = name
+
+        return response_object_or_error("Template", resp, 200)
+
+
+    def delete(self):
+        """ Delete Template """
+        resp = self.conn.http_delete(f"{self.conn.url}/api/templates/{self.name}")
+        return response_object_or_error("Template", resp, 204)

--- a/python/tests/kadalu_content_api_pytest.py
+++ b/python/tests/kadalu_content_api_pytest.py
@@ -287,3 +287,71 @@ def test_delete_object_with_bucket():
     # List of default objects after deletion
     objects = bucket.list_objects()
     assert len(objects) == 0
+
+
+def test_create_template():
+    conn = kadalu_content_apis.Connection(
+        url=URL,
+        user_id=USER_ID,
+        token=TOKEN
+    )
+
+    content = """Hello <b>{{ data["first_name"] }}</b>"""
+    tmpl = conn.create_template("simple-html", content, "html")
+
+    assert len(conn.list_templates()) == 1
+    assert tmpl.name == "simple-html"
+
+
+def test_list_templates():
+    conn = kadalu_content_apis.Connection(
+        url=URL,
+        user_id=USER_ID,
+        token=TOKEN
+    )
+
+    content = """Hello <b>{{ data["last_name"] }}</b>"""
+    tmpl = conn.create_template("simple-html-2", content, "html")
+
+    assert len(conn.list_templates()) == 2
+
+
+def test_get_template():
+    conn = kadalu_content_apis.Connection(
+        url=URL,
+        user_id=USER_ID,
+        token=TOKEN
+    )
+
+    tmpl = conn.template("simple-html")
+    get_data = tmpl.get()
+
+    assert get_data.name == "simple-html"
+    assert get_data.type == "html"
+    assert get_data.output_type == "text"
+
+
+def test_update_template():
+    conn = kadalu_content_apis.Connection(
+        url=URL,
+        user_id=USER_ID,
+        token=TOKEN
+    )
+
+    tmpl = conn.template("simple-html")
+    updated_tmpl = tmpl.update(public=True)
+
+    assert updated_tmpl.public == True
+
+
+def test_delete_template():
+    conn = kadalu_content_apis.Connection(
+        url=URL,
+        user_id=USER_ID,
+        token=TOKEN
+    )
+
+    tmpl = conn.template("simple-html-2")
+    tmpl.delete()
+
+    assert len(conn.list_templates()) == 1


### PR DESCRIPTION
Upload file by specifying file_path="/extra/examples/objects.json" and path will be automatically set to "objects.json".

```
Can upload objects with buckets through:
bucket = conn.bucket("mydocs")
bucket.upload(file_path, object_type="json", ....)
```

```
Or for default objects:
conn.upload_objects(file_path, object_type="json", .....)
```

Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>