### PR TITLE
Return respective object instead of generic object

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+      - name: Generate version file
+        working-directory: python
+        run: |
+          echo "VERSION = \"${{ env.content_apis_version }}\"" > kadalu_content_apis/version.py
       - name: Publish to Pypi
         working-directory: python
         run: |

--- a/python/kadalu_content_apis/__init__.py
+++ b/python/kadalu_content_apis/__init__.py
@@ -69,7 +69,7 @@ class Connection(ConnectionBase):
                 if line.strip() == "":
                     continue
                 key, value = line.split("=", 1)
-                env_vars[key] = value
+                env_vars[key.strip()] = value.strip()
 
         return Connection(
             env_vars["URL"],

--- a/python/kadalu_content_apis/shares.py
+++ b/python/kadalu_content_apis/shares.py
@@ -1,12 +1,13 @@
-from kadalu_content_apis.helpers import response_object_or_error
+from kadalu_content_apis.helpers import response_object_or_error, Generic
 
 class Share:
-    def __init__(self, conn, folder_name, path, share_id):
+    def __init__(self, conn=None, folder_name=None, path=None, share_id=None, data=None):
         """ Intialise Document/Object """
         self.conn = conn
         self.folder_name = folder_name
         self.path = path
-        self.share_id = share_id
+        self.id = share_id
+        super().__init__(data)
 
 
     @classmethod
@@ -34,8 +35,12 @@ class Share:
                 "role": role
             }
         )
-        return response_object_or_error("Share", resp, 201)
+        outdata = response_object_or_error(Share, resp, 201)
+        outdata.conn = conn
+        outdata.folder_name = folder_name
+        outdata.path = path
 
+        return outdata
 
     @classmethod
     def list(cls, conn, folder_name, path):
@@ -50,13 +55,21 @@ class Share:
             url = f"{conn.url}/api/shares/objects/{path}"
 
         resp = conn.http_get(url)
-        return response_object_or_error("Share", resp, 200)
+        shares = response_object_or_error(Share, resp, 200)
 
+        def update_data(share):
+            share.conn = conn
+            share.folder_name = folder_name
+            share.path = path
+
+            return share
+
+        return list(map(update_data, shares))
 
     def update(self, disable=False, revoke=False, expire=False):
         """ Update share options """
 
-        url = f"{self.conn.url}/api/shares/{self.share_id}"
+        url = f"{self.conn.url}/api/shares/{self.id}"
 
         resp = self.conn.http_put(
             url,
@@ -66,13 +79,15 @@ class Share:
                 "expire": expire
             }
         )
-        return response_object_or_error("Share", resp, 200)
+        outdata = response_object_or_error(Share, resp, 200)
+        outdata.conn = self.conn
 
+        return outdata
 
     def delete(self):
         """ Delete object of both default("/") and with folder-name """
 
-        url = f"{self.conn.url}/api/shares/{self.share_id}"
+        url = f"{self.conn.url}/api/shares/{self.id}"
         resp = self.conn.http_delete(url)
-        return response_object_or_error("Share", resp, 204)
+        return response_object_or_error(Share, resp, 204)
 

--- a/python/kadalu_content_apis/templates.py
+++ b/python/kadalu_content_apis/templates.py
@@ -1,10 +1,11 @@
-from kadalu_content_apis.helpers import response_object_or_error
+from kadalu_content_apis.helpers import response_object_or_error, Generic
 
-class Template:
-    def __init__(self, conn, name):
+class Template(Generic):
+    def __init__(self, conn=None, name=None, data=None):
         """ Intialise Template """
         self.conn = conn
         self.name = name
+        super().__init__(data)
 
 
     # TODO: Handle Invalid Region Name, when only name is passed.
@@ -23,8 +24,10 @@ class Template:
 
             }
         )
-        return response_object_or_error("Template", resp, 201)
+        outdata = response_object_or_error(Template, resp, 201)
+        outdata.conn = conn
 
+        return outdata
 
     @classmethod
     def upload(cls, conn, file_path, template_type, name, output_type, public):
@@ -48,8 +51,10 @@ class Template:
             f"{conn.url}/api/templates",
             meta, file_path, file_content
         )
-        return response_object_or_error("Template", resp, 201)
+        outdata = response_object_or_error(Template, resp, 201)
+        outdata.conn = conn
 
+        return outdata
 
     @classmethod
     def list_templates(cls, conn):
@@ -58,8 +63,14 @@ class Template:
         resp = conn.http_get(
             f"{conn.url}/api/templates"
         )
-        return response_object_or_error("Template", resp, 200)
+        templates = response_object_or_error(Template, resp, 200)
 
+        def update_data(tmpl):
+            tmpl.conn = conn
+
+            return tmpl
+
+        return list(map(update_data, templates))
 
     def get(self):
         """ Return a Template """
@@ -67,7 +78,10 @@ class Template:
         resp = self.conn.http_get(
             f"{self.conn.url}/api/templates/{self.name}"
         )
-        return response_object_or_error("Template", resp, 200)
+        outdata = response_object_or_error(Template, resp, 200)
+        outdata.conn = self.conn
+
+        return outdata
 
 
     def update(self, name=None, content=None, template_type=None, output_type=None, public=None):
@@ -88,10 +102,13 @@ class Template:
         if resp.status == 200 and name is not None:
             self.name = name
 
-        return response_object_or_error("Template", resp, 200)
+        outdata = response_object_or_error(Template, resp, 200)
+        outdata.conn = self.conn
+
+        return outdata
 
 
     def delete(self):
         """ Delete Template """
         resp = self.conn.http_delete(f"{self.conn.url}/api/templates/{self.name}")
-        return response_object_or_error("Template", resp, 204)
+        return response_object_or_error(Template, resp, 204)


### PR DESCRIPTION
List folders returns list of Folder objects and create_folder will return the folder object.

Update connection and other required details to the returned object, so that the object can handle further calls.

Below code will work with this PR

```python
from kadalu_content_apis import Connection

conn = Connection.from_env_file("/home/ubuntu/kca_admin.env")
folder = conn.create_folder("mydocs")
print(folder.list_objects())
```